### PR TITLE
Update to 13.2.0-2+flatpak.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,18 +3,18 @@
   SPDX-License-Identifier: CC0-1.0
 -->
 
-# GNAT Ada Compiler as Freedesktop SDK Extension
+# Freedesktop SDK Ada Extension with GNAT 13
 
-This folder contains necessary files to repack an GNAT-based Ada development environment into an extention to the `org.freedesktop.Sdk` Flatpak container.
+This folder contains necessary files to repack an GNAT-13-based Ada development environment into an extention to the `org.freedesktop.Sdk` Flatpak container image.
 
 ## Includes
 
-- GNAT-FSF (Ada/GCC)
-- GNATprove (SPARK)
-- GPRbuild
-- Alire (`alr`)
+- GNAT-FSF (Ada/GCC) 13.x
+- GNATprove (SPARK) 13.x
+- GPRbuild latest
+- Alire (`alr`) latest
 
-So far the manifest simply downloads pre-built binaries from [alire-project/GNAT-FSF-builds](https://github.com/alire-project/GNAT-FSF-builds/releases).
+So far the manifest simply downloads pre-built binaries from [alire-project/GNAT-FSF-builds](https://github.com/alire-project/GNAT-FSF-builds/releases) and [alire-project/alire](https://github.com/alire-project/alire).
 
 ## License
 

--- a/org.freedesktop.Sdk.Extension.gnat13.metainfo.xml
+++ b/org.freedesktop.Sdk.Extension.gnat13.metainfo.xml
@@ -25,6 +25,20 @@
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>GPL-3.0-or-later</project_license>
   <releases>
+    <release version="13.2.0-2+flatpak.3.0" date="2024-10-29">
+      <description>
+        <p>This release updates the following components:</p>
+        <ul>
+          <li>GNAT: from 13.2.0-1 to 13.2.0-2</li>
+          <li>GPRbuild: from 24.0.0-1 to 24.0.0-2</li>
+          <li>Alire: from 2.0.1 to 2.0.2</li>
+        </ul>
+        <p>The following components are unchanged:</p>
+        <ul>
+          <li>GNATprove: 13.2.0-1</li>
+        </ul>
+      </description>
+    </release>
     <release version="13.2.0-1+flatpak.2.0" date="2024-03-28">
       <description>
         <p>This release updates the following components:</p>

--- a/org.freedesktop.Sdk.Extension.gnat13.yml
+++ b/org.freedesktop.Sdk.Extension.gnat13.yml
@@ -18,8 +18,8 @@ modules:
       - cp -R * /usr/lib/sdk/gnat13
     sources:
       - type: archive
-        url: https://github.com/alire-project/GNAT-FSF-builds/releases/download/gnat-13.2.0-1/gnat-x86_64-linux-13.2.0-1.tar.gz
-        sha256: 788a01f91f54259a6a9fb44f0c1f36b83cbf0ef06a8e6a9c601a4c46581a07a8
+        url: https://github.com/alire-project/GNAT-FSF-builds/releases/download/gnat-13.2.0-2/gnat-x86_64-linux-13.2.0-2.tar.gz
+        sha256: a27fd7945ac9ead50abdd8e4564d133d00f635536bf9dfdf1e00af5e08a0c494
 
   - name: gnatprove
     only-arches:
@@ -40,8 +40,8 @@ modules:
       - cp -R * /usr/lib/sdk/gnat13
     sources:
       - type: archive
-        url: https://github.com/alire-project/GNAT-FSF-builds/releases/download/gprbuild-24.0.0-1/gprbuild-x86_64-linux-24.0.0-1.tar.gz
-        sha256: 4bb020f375a90bdec348390c44e517af42d2724fb439b00c4738992c42a931c6
+        url: https://github.com/alire-project/GNAT-FSF-builds/releases/download/gprbuild-24.0.0-2/gprbuild-x86_64-linux-24.0.0-2.tar.gz
+        sha256: 5b8a03895d56c81ce8592dd9494c9b1f0a526ed958ba594753584fa8bfe3faf1
 
   - name: alire
     only-arches:
@@ -51,8 +51,8 @@ modules:
       - install -Dm755 -t /usr/lib/sdk/gnat13/bin alr
     sources:
       - type: archive
-        url: https://github.com/alire-project/alire/releases/download/v2.0.1/alr-2.0.1-bin-x86_64-linux.zip
-        sha256: 8f4b39f42fd6969815077f91fdae087b8309eedda069ad5227374c49807792a1
+        url: https://github.com/alire-project/alire/releases/download/v2.0.2/alr-2.0.2-bin-x86_64-linux.zip
+        sha256: 579de127341a1a684e07410b8b7a15ea7c2b39c47fd1a21179202203afe4be23
 
   - name: enable-sh
     buildsystem: simple


### PR DESCRIPTION
This PR brings components in org.freedesktop.Sdk.Extension.gnat13 to their latest version. In addition, README.md is rephrased to try being clear about version policies of components in this extension.