### PR TITLE
13.2.0-2+flatpak.5.0 for 23.08

### DIFF
--- a/org.freedesktop.Sdk.Extension.gnat13.metainfo.xml
+++ b/org.freedesktop.Sdk.Extension.gnat13.metainfo.xml
@@ -25,6 +25,20 @@
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>GPL-3.0-or-later</project_license>
   <releases>
+    <release version="13.2.0-2+flatpak.5.0" date="2025-06-23">
+      <description>
+        <p>This release updates the following components:</p>
+        <ul>
+          <li>GPRbuild: from 24.0.0-2 to 25.0.0-1</li>
+        </ul>
+        <p>The following components remain unchanged:</p>
+        <ul>
+          <li>GNAT: 13.2.0-2</li>
+          <li>GNATprove: 13.2.0-1</li>
+          <li>Alire: 2.1.0</li>
+        </ul>
+      </description>
+    </release>
     <release version="13.2.0-2+flatpak.4.0" date="2025-03-04">
       <description>
         <p>This release updates the following components:</p>

--- a/org.freedesktop.Sdk.Extension.gnat13.yml
+++ b/org.freedesktop.Sdk.Extension.gnat13.yml
@@ -40,8 +40,8 @@ modules:
       - cp -R * /usr/lib/sdk/gnat13
     sources:
       - type: archive
-        url: https://github.com/alire-project/GNAT-FSF-builds/releases/download/gprbuild-24.0.0-2/gprbuild-x86_64-linux-24.0.0-2.tar.gz
-        sha256: 5b8a03895d56c81ce8592dd9494c9b1f0a526ed958ba594753584fa8bfe3faf1
+        url: https://github.com/alire-project/GNAT-FSF-builds/releases/download/gprbuild-25.0.0-1/gprbuild-x86_64-linux-25.0.0-1.tar.gz
+        sha256: 9a2e6cfb9c4add85c7c411e95533c46728aae7de19a9a0b056abf53bd9795b0d
 
   - name: alire
     only-arches:


### PR DESCRIPTION
This release updates the following components:

- GPRbuild: from 24.0.0-2 to 25.0.0-1

The following components remain unchanged:

- GNAT: 13.2.0-2
- GNATprove: 13.2.0-1
- Alire: 2.1.0